### PR TITLE
chore: mainブランチへのpushとPR時にのみdeployするよう変更

### DIFF
--- a/.github/workflows/publish-to-cloudflare-pages.yml
+++ b/.github/workflows/publish-to-cloudflare-pages.yml
@@ -3,6 +3,11 @@ name: Publish to Cloudflare Pages
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   publish:


### PR DESCRIPTION
main以外のブランチへのpushではpreview deployしないよう変更した。代わりに、mainブランチへのPR時にpewview deployするようにした。